### PR TITLE
Git cloning for workflow instances repo

### DIFF
--- a/.env
+++ b/.env
@@ -2,6 +2,12 @@
 NGINX_SERVER_HOSTNAME=localhost
 #NGINX_SERVER_HOSTNAME=myserver.subdomain.domain
 
+# Directory on the server host where the Mongo data is  kept (will be mounted on /data/db/ on the api container)
+MONGO_DATA_DIRECTORY=~/mongodata
+
+# Directory on the server host where the cloned GitHub repos are kept (will be mounted on /data/github/ on the api container)
+GITHUB_DATA_DIRECTORY=~/githubdata
+
 # Port that Nginx uses to listen to outside connection. Use either 80 (http) or 443 (https).
 NGINX_PORT=80
 #NGINX_PORT=443
@@ -27,9 +33,11 @@ NGINX_SSL_PRIVATE_KEY_PATH=
 #NGINX_SSL_PRIVATE_KEY_PATH=/etc/letsencrypt/live/dirt02.ics.hawaii.edu/privkey.pem
 
 # Controls the interval for inspecting/analyzing/pulling workflow instances from the WfInstances repo,
-# measured in days. Note that the Web app is unavailable while the crawl is happening.
-WFINSTANCES_CRAWL_PERIOD_IN_DAYS=7
+# measured in days. Note that the Web app is unavailable while the crawl is happening.0.04167 is around 1 hour.
+WFINSTANCES_CRAWL_PERIOD_IN_DAYS=0.04167
 
+# Path the a file that contains the IPInfo.io API token
+IPINFO_DOT_IO_TOKEN_FILE=tmp/ipinfo_token.txt
 
 # Customization of the API dockerfile, if necessary when running/testing on a Mac
 API_DOCKERFILE_NAME=Dockerfile

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -3,29 +3,31 @@ USER root
 
 COPY requirements.txt .
 
-RUN pip install -r requirements.txt
+RUN pip install --break-system-packages -r requirements.txt
 
-RUN apt-get update && apt-get install -y curl
+RUN apt-get update && apt-get install -y git
 
 RUN apt-get install -y cron
 
-RUN echo '#!/bin/sh\ncurl -X PUT http://localhost:8081/metrics/private/github/wfcommons/WfInstances' > /usr/local/bin/workflowInjection.sh
+RUN mkdir -p /data/github
 
-RUN chmod +x /usr/local/bin/workflowInjection.sh
+RUN git clone https://github.com/wfcommons/WfInstances.git /data/github
 
 ARG WFINSTANCES_CRAWL_PERIOD_IN_DAYS
 
-RUN  echo "0 0 */${WFINSTANCES_CRAWL_PERIOD_IN_DAYS} * *  /usr/local/bin/workflowInjection.sh" > /etc/cron.d/run-curl-job
+RUN echo "0 * * * * cd /data/github && git pull origin main" > /etc/cron.d/git-pull-repo
 
-RUN chmod 0644 /etc/cron.d/run-curl-job
+RUN chmod 0644 /etc/cron.d/git-pull-repo
 
-RUN crontab /etc/cron.d/run-curl-job
+RUN crontab /etc/cron.d/git-pull-repo
 
 # Install WRENCH API v0.4
 RUN apt-get -y install zip
-RUN python3 -m pip install build
-RUN wget https://github.com/wrench-project/wrench-python-api/archive/refs/tags/v0.4.zip; unzip v0.4.zip; cd wrench-python-api-0.4; python3 -m build; python3 -m pip install ./dist/wrench-*.whl
+RUN python3 -m pip install --break-system-packages build
+RUN wget https://github.com/wrench-project/wrench-python-api/archive/refs/tags/v0.4.zip; unzip v0.4.zip; cd wrench-python-api-0.4; python3 -m build; python3 -m pip install --break-system-packages ./dist/wrench-*.whl
 
+# Intall IPInfo
+RUN python3 -m pip install --break-system-packages ipinfo
 
 COPY . .
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -8,3 +8,4 @@ pymongo[srv]
 requests
 starlette
 uvicorn
+gitpython

--- a/api/src/metrics/service.py
+++ b/api/src/metrics/service.py
@@ -5,6 +5,10 @@ from src.metrics.graph import Graph
 from src.exceptions import InvalidWfInstanceException, GithubResourceNotFoundException
 from src.wfinstances.service import validate_wf_instance
 import sys
+import os
+import json
+import time
+import git
 
 
 def insert_metrics_from_github(owner: str, repo: str) -> tuple[list, list]:
@@ -22,42 +26,63 @@ def insert_metrics_from_github(owner: str, repo: str) -> tuple[list, list]:
     """
     valid_wf_instances, invalid_wf_instances = [], []
 
-    def recurse_dir(path='') -> None:
-        response = requests.get(f'https://api.github.com/repos/{owner}/{repo}/contents/{path}')
-        if response.status_code != 200:
-            raise GithubResourceNotFoundException('repository')
-        files = response.json()
+    # Set up the repository URL and local directory
+    repo_url = f"https://github.com/{owner}/{repo}.git"
+    local_dir = f"/data/github/{repo}"
 
+    # Clone the repository if it doesn't exist locally
+    if not os.path.exists(local_dir):
+        print(f"Cloning repository {repo_url} into {local_dir}...")
+        git.Repo.clone_from(repo_url, local_dir)
+    else:
+        print(f"Repository already exists locally. Pulling the latest changes...")
+        repo = git.Repo(local_dir)
+        origin = repo.remotes.origin
+        origin.pull()
+
+    # Now that the repository is cloned or updated, looking for .json files
+    now = time.time()
+    for root, dirs, files in os.walk(local_dir):
         for file in files:
-            if file['type'] == 'dir':
-                recurse_dir(file['path'])
-            elif str.endswith(file['name'], '.json'):
-                sys.stderr.write(f"Inspecting file {file['name']}\n")
-                response = requests.get(file['download_url'])
-                if response.status_code != 200:
-                    raise GithubResourceNotFoundException('download_url')
-                wf_instance = response.json()
+            if file.endswith('.json'):
+                file_path = os.path.join(root, file)
+                if now > os.path.getmtime(file_path):
+                    sys.stderr.write(f"Skipping unchanged file {file}\n")
+                    continue
+                else:
+                    sys.stderr.write(f"Inspecting updated file {file}\n")
 
+                # Read the JSON file
+                try:
+                    with open(file_path, "r", encoding="utf-8") as f:
+                        wf_instance = json.load(f)
+                except json.JSONDecodeError:
+                    sys.stderr.write(f"Invalid JSON format: {file}\n")
+                    invalid_wf_instances.append(file)
+                    continue
+
+                # Validate the WfInstance schema
                 try:
                     validate_wf_instance(wf_instance)
                 except InvalidWfInstanceException:
-                    invalid_wf_instances.append(file['name'])
+                    invalid_wf_instances.append(file)
                     continue
 
-                valid_wf_instances.append(file['name'])
+                valid_wf_instances.append(file)
 
-                # Replace if already exists, otherwise add into metrics_collection
+                # Generate metrics and store them in the database
                 metrics = _generate_metrics(wf_instance)
-                metrics['_id'] = file['name']
-                metrics['_githubRepo'] = f'{owner}/{repo}'
-                metrics['_downloadUrl'] = file['download_url']
+                metrics["_id"] = file
+                metrics["_githubRepo"] = f"{owner}/{repo}"
+                metrics["_filePath"] = file_path
                 metrics_collection.find_one_and_update(
-                    {'_id': metrics['_id']},
-                    {'$set': metrics},
-                    upsert=True)
+                    {"_id": metrics["_id"]},
+                    {"$set": metrics},
+                    upsert=True,
+                )
 
-    recurse_dir()
     return valid_wf_instances, invalid_wf_instances
+
 
 
 def _generate_metrics(wf_instance: dict) -> dict:


### PR DESCRIPTION
Git clone of repo and keep JSONs locally. Refactor way we look at workflow instances and disable outside route of we get usage statistics.

(From https://github.com/wfcommons/wfinstances-browser/issues/61)
Currently, it takes a while to populate the local database based on crawling the GitHub repo. Instead, we should be smart, and detect that when a workflow hasn't changed since last time we retrieved it then we don't need to retrieve it again. This could entail a redesign, where the WfCommon instances are actually "git pulled" from the WfCommons github, as opposed to curl-ed. This would entail quite a few changes, where instead of always re-downloading from the github, one would instead read a local file. And a cront job would be set up to do a git pull every hour for instance.

1.add gitpython to the requirement.txt file.(use for service.py git hub clone and pull)
2.change the crawl at the env. file to 1 hour.
3. switched from using curl to git for cloning and updating the GitHub repository(service.py)